### PR TITLE
fix: set core.js as package entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ssb-browser-core",
   "description": "",
   "version": "3.1.1",
+  "main": "core.js",
   "homepage": "https://github.com/arj03/ssb-browser-core",
   "repository": {
     "type": "git",


### PR DESCRIPTION
this make `require("ssb-browser-core")` work directly