### PR TITLE
Bump ssb-keys to 8.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4100,15 +4100,26 @@
       }
     },
     "ssb-keys": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-8.0.1.tgz",
-      "integrity": "sha512-UrNf65+pCM+XT9kAzKbz438xft3ymRBKFtd0xCCWhyIm5U0CzATw8dhyEBSIbwJ9Ibf4eGZKq1xnEPqlWsf7gA==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-8.0.2.tgz",
+      "integrity": "sha512-u2U9t5YLbFShKQzr+ayMx9cYNvUJzDeOScodMwfP5zM3+/1AStvc5W91knZGllGwsmGjNC57KW+whRun+H/dBQ==",
       "requires": {
-        "chloride": "~2.4.0",
+        "chloride": "~2.4.1",
         "mkdirp": "~0.5.0",
         "private-box": "~0.3.0"
       },
       "dependencies": {
+        "chloride": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chloride/-/chloride-2.4.1.tgz",
+          "integrity": "sha512-ZiID87W2o2llvuF4C7Fvt9GJisazSdMsSkjAq4WaMed9zn77nlkcy08ZfrPtOGAXyaxTDj0VjnuyD97EdJLz3g==",
+          "requires": {
+            "sodium-browserify": "^1.2.7",
+            "sodium-browserify-tweetnacl": "^0.2.5",
+            "sodium-chloride": "^1.1.2",
+            "sodium-native": "^3.0.0"
+          }
+        },
         "mkdirp": {
           "version": "0.5.5",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ssb-caps": "^1.1.0",
     "ssb-conn": "^1.0.0",
     "ssb-db2": "^1.7.0",
-    "ssb-keys": "^8.0.1",
+    "ssb-keys": "^8.0.2",
     "ssb-no-auth": "^1.0.0",
     "ssb-ref": "^2.14.3",
     "ssb-room": "^1.3.0",


### PR DESCRIPTION
Bumps ssb-keys to 8.0.2 to get rid of the unnecessary errors from chloride.