### PR TITLE
Add offline mode

### DIFF
--- a/core.js
+++ b/core.js
@@ -61,9 +61,11 @@ exports.init = function (dir, config) {
     }
 
     // delay startup a bit
-    setTimeout(() => {
-      SSB.net.conn.start()
-    }, 2000)
+    if (!config.core || !config.core.startOffline) {
+      setTimeout(() => {
+        SSB.net.conn.start()
+      }, 2000)
+    }
 
     SSB.events.emit("SSB: loaded")
   })

--- a/core.js
+++ b/core.js
@@ -61,7 +61,8 @@ exports.init = function (dir, config) {
     }
 
     // delay startup a bit
-    if (!config.core || !config.core.startOffline) {
+    const startOffline = config.core && config.core.startOffline
+    if (!startOffline) {
       setTimeout(() => {
         SSB.net.conn.start()
       }, 2000)


### PR DESCRIPTION
Adds support for starting without the connection scheduler active, effectively putting ssb-browser-core in offline mode if asked.

See https://github.com/arj03/ssb-browser-demo/issues/153