### PR TITLE
Pass missing blob errors back rather than crash

### DIFF
--- a/simple-blobs.js
+++ b/simple-blobs.js
@@ -353,13 +353,18 @@ exports.init = function (sbot, config) {
     const file = raf(sanitizedPath(id))
     file.stat((err, stat) => {
       if (stat && stat.size == 0) {
-        httpGet(remoteURL(id), 'blob', (err, data) => {
-          if (err) cb(err)
-          else if (data && data.size < max)
-            add(id, data, () => { fsURL(id, cb) })
-          else
-            cb(null, remoteURL(id))
-        })
+        const url = remoteURL(id)
+        if (url && url != '') {
+          httpGet(url, 'blob', (err, data) => {
+            if (err) cb(err)
+            else if (data && data.size < max)
+              add(id, data, () => { fsURL(id, cb) })
+            else
+              cb(null, url)
+          })
+        } else {
+          cb("Blob not in local storage")
+        }
       }
       else
       {


### PR DESCRIPTION
Rather than crashing if there is no active connection to a server, pass the error back up the chain so it can be gracefully handled.

See https://github.com/arj03/ssb-browser-demo/issues/76#issuecomment-762892413