### PR TITLE
Pass last updated timestamp back up

### DIFF
--- a/simple-ebt.js
+++ b/simple-ebt.js
@@ -109,6 +109,7 @@ exports.init = function (sbot, config) {
           var rep = peer.replicating && peer.replicating[id]
           data.peers[k] = {
             seq: peer.clock[id],
+            ts: peer.ts,
             replicating: rep
           }
         }


### PR DESCRIPTION
> Please note in browser-core we don't use ssb-ebt directly because it has a wierd interaction with the replication plugin. So you need to change it [here](https://github.com/arj03/ssb-browser-core/blob/793cc80b042d9fd8daac699174c8b8f84586b406/simple-ebt.js#L111) instead. I'm not sure how good this information will be, as I haven't used it for anything, but could be interesting to see. Come to think of it, EBT should have a concept of stalled peers, but looking that up only reveals some tests. Might be a bit of a rabit hole :)

From @arj here: https://github.com/arj03/ssb-browser-demo/issues/141#issuecomment-781143630

This adds the timestamp (if there is one) to peer status so we can display it in the UI.