### PR TITLE
Fix error when clock is undefined

### DIFF
--- a/simple-ebt.js
+++ b/simple-ebt.js
@@ -36,7 +36,7 @@ exports.init = function (sbot, config) {
     id: sbot.id,
     getClock: function (id, cb) {
       readFile(path.join(config.path, 'ebt', id)).then(clock => {
-        clock = JSON.parse(clock) || {}
+        clock = (clock && JSON.parse(clock)) || {}
         cleanClock(clock)
         cb(null, clock)
       })


### PR DESCRIPTION
Turns out if you haven't synced with anything yet, `clock` comes in as `undefined`.  This errors out `JSON.parse` with an error about an unknown token "u".  This should fix that.