### PR TITLE
Update ssb-conn to new 2.0.2 version which doesn't use zii

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "ssb-browser-core",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "9.0.0",
+      "version": "9.1.0",
       "license": "Beerware",
       "dependencies": {
         "atomically-universal": "^0.1.1",
@@ -26,7 +26,7 @@
         "secret-stack": "^6.3.2",
         "ssb-blob-files": "https://github.com/ssbc/ssb-blob-files#browser-support",
         "ssb-caps": "^1.1.0",
-        "ssb-conn": "^1.0.0",
+        "ssb-conn": "^2.0.2",
         "ssb-db2": "^1.17.0",
         "ssb-friends": "^4.4.4",
         "ssb-keys": "^8.0.2",
@@ -3968,11 +3968,11 @@
       "integrity": "sha512-qe3qpvchJ+gnH8M/ge4rpL+7eRbSmsEAzNwHkDdrW06OBcziQ6/KuAdmcR6joxCbNeoAXAZF+inkefgE16okXA=="
     },
     "node_modules/ssb-conn": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ssb-conn/-/ssb-conn-1.0.0.tgz",
-      "integrity": "sha512-hFJS+VZIiQHToN/GuhKdOAG8BLnb93mKQGY74uj03cY8Dz89kAjcq17+KYRlnJL5bgcvczYl04ewOzm9MjfV0A==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ssb-conn/-/ssb-conn-2.0.2.tgz",
+      "integrity": "sha512-ZwV7dKXX3PxHYKRr/HGJZX7SfbI+J6UoMTSxgpr6UXPbFQV/9+hosLXkMTpnKL7m3bL/tbKwTrPqKhKJeXxtdQ==",
       "dependencies": {
-        "debug": "~4.2.0",
+        "debug": "^4.3.0",
         "has-network2": ">=0.0.3",
         "ip": "^1.1.5",
         "on-change-network-strict": "1.0.0",
@@ -3982,34 +3982,29 @@
         "pull-ping": "^2.0.3",
         "pull-stream": "^3.6.14",
         "secret-stack-decorators": "1.1.0",
-        "ssb-conn-db": "~0.3.3",
-        "ssb-conn-hub": "~0.2.7",
-        "ssb-conn-query": "~0.4.6",
-        "ssb-conn-staging": "~0.1.0",
-        "ssb-ref": "^2.14.2",
-        "ssb-typescript": "^2.1.0",
+        "ssb-conn-db": "~1.0.1",
+        "ssb-conn-hub": "~1.0.0",
+        "ssb-conn-query": "~1.0.0",
+        "ssb-conn-staging": "~1.0.0",
+        "ssb-ref": "^2.14.3",
+        "ssb-typescript": "^2.2.0",
         "statistics": "^3.3.0",
-        "zii": "~1.1.0"
+        "ziii": "~1.0.2"
+      },
+      "peerDependencies": {
+        "secret-stack": ">=6.2.0"
       }
     },
     "node_modules/ssb-conn-db": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/ssb-conn-db/-/ssb-conn-db-0.3.3.tgz",
-      "integrity": "sha512-N2C/PweOlzEnrcfhGusnFhrZusfGyEMqip2WpQR/dgLAwHHQK8Wxn9KkC0457AHYlIO3UDH4Q1Mewsz8RLweMw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ssb-conn-db/-/ssb-conn-db-1.0.1.tgz",
+      "integrity": "sha512-lTXhHmJ9La7S+YFotLnvn+4uxX5lP+zDNS3N4zPnDDy/3f1AQI6jxEnRDmbhfWqrAEI2gy7Yu6LcgC5rX+MRDA==",
       "dependencies": {
         "atomic-file": "^2.1.1",
-        "debug": "~4.1.1",
+        "debug": "^4.3.1",
         "multiserver-address": "~1.0.1",
         "pull-notify": "~0.1.1",
         "ssb-ref": "~2.13.9"
-      }
-    },
-    "node_modules/ssb-conn-db/node_modules/debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "dependencies": {
-        "ms": "^2.1.1"
       }
     },
     "node_modules/ssb-conn-db/node_modules/ssb-ref": {
@@ -4024,9 +4019,9 @@
       }
     },
     "node_modules/ssb-conn-hub": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/ssb-conn-hub/-/ssb-conn-hub-0.2.7.tgz",
-      "integrity": "sha512-fvX7HK44V65C8uMQhTK9B4SHZE7K5P0AU/cHVuDciKPNagEFV0QHKk//JnrrMKHKKvz1msKUxhA0S0iH0S4gqQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ssb-conn-hub/-/ssb-conn-hub-1.0.0.tgz",
+      "integrity": "sha512-YVtQqWmmfT/rDmlCzalP52DsYPF0nUGyADa2Tmvd3gXPS65WnwOA8rtkiDEcTs52OPM+yTO8uG7qLkW534KkKA==",
       "dependencies": {
         "debug": "^4.1.1",
         "ip": "^1.1.5",
@@ -4051,36 +4046,25 @@
       }
     },
     "node_modules/ssb-conn-query": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/ssb-conn-query/-/ssb-conn-query-0.4.6.tgz",
-      "integrity": "sha512-qwa0xYK4r3DwbJQQ/K5umw4VAt3aGTkRbFN0E43Mb33+M94jnXMhDIxZWrPoX1vVQSRZLlCb+laXQiGlxW32AQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ssb-conn-query/-/ssb-conn-query-1.0.0.tgz",
+      "integrity": "sha512-sAxy+nJ6B5S9mYuEGT/aMFkPzDKuABdM1eC9XEAvIK8MS3nssjlKe216Tgo63ds4hyK/dghr5D4gd+o5WMcaQA==",
       "dependencies": {
-        "ssb-conn-db": "~0.3.3",
-        "ssb-conn-hub": "~0.2.7",
-        "ssb-conn-staging": "~0.1.0"
+        "ssb-conn-db": "~1.0.0",
+        "ssb-conn-hub": "~1.0.0",
+        "ssb-conn-staging": "~1.0.0"
       }
     },
     "node_modules/ssb-conn-staging": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/ssb-conn-staging/-/ssb-conn-staging-0.1.0.tgz",
-      "integrity": "sha512-bFtArSUiF3QrJ9LJ1auonC40pxJd58eBzozBiWsburwbZLUuxqrnW/kCaoyu+PYwTvc0FvMzZR/g4yL2wcE4Yw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ssb-conn-staging/-/ssb-conn-staging-1.0.0.tgz",
+      "integrity": "sha512-NOy1qZoBkhH0XNzLteaaKKePXigEJSCntD4RPRU6vWLMlQ10+SzlIz4TWKgvEVx0LfCe6tEx/vhQf6vBWO/Ylw==",
       "dependencies": {
         "debug": "^4.1.1",
         "multiserver-address": "~1.0.1",
         "pull-cat": "~1.1.11",
         "pull-notify": "~0.1.1",
         "pull-stream": "^3.6.9"
-      }
-    },
-    "node_modules/ssb-conn/node_modules/debug": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
       }
     },
     "node_modules/ssb-db2": {
@@ -5002,10 +4986,10 @@
         "node": ">=0.4"
       }
     },
-    "node_modules/zii": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/zii/-/zii-1.1.0.tgz",
-      "integrity": "sha512-l4EKO8dgLsEWxdb/koCjv92FplAIAQaV4Riq5n/38dTC7Z3NwaFSKQ5Bda+CUTu11VtFE1D+4+HPfPt7/86CRw=="
+    "node_modules/ziii": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ziii/-/ziii-1.0.2.tgz",
+      "integrity": "sha512-q1FogtBIchy1W0fkxUpe6A4n4WUvAM+hAHN1J6LjBNCV42ZegeC5JSz0mcNv4qxnI0V4cL4FNeEhPMm97Ed0kA=="
     }
   },
   "dependencies": {
@@ -8526,11 +8510,11 @@
       "integrity": "sha512-qe3qpvchJ+gnH8M/ge4rpL+7eRbSmsEAzNwHkDdrW06OBcziQ6/KuAdmcR6joxCbNeoAXAZF+inkefgE16okXA=="
     },
     "ssb-conn": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ssb-conn/-/ssb-conn-1.0.0.tgz",
-      "integrity": "sha512-hFJS+VZIiQHToN/GuhKdOAG8BLnb93mKQGY74uj03cY8Dz89kAjcq17+KYRlnJL5bgcvczYl04ewOzm9MjfV0A==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ssb-conn/-/ssb-conn-2.0.2.tgz",
+      "integrity": "sha512-ZwV7dKXX3PxHYKRr/HGJZX7SfbI+J6UoMTSxgpr6UXPbFQV/9+hosLXkMTpnKL7m3bL/tbKwTrPqKhKJeXxtdQ==",
       "requires": {
-        "debug": "~4.2.0",
+        "debug": "^4.3.0",
         "has-network2": ">=0.0.3",
         "ip": "^1.1.5",
         "on-change-network-strict": "1.0.0",
@@ -8540,46 +8524,28 @@
         "pull-ping": "^2.0.3",
         "pull-stream": "^3.6.14",
         "secret-stack-decorators": "1.1.0",
-        "ssb-conn-db": "~0.3.3",
-        "ssb-conn-hub": "~0.2.7",
-        "ssb-conn-query": "~0.4.6",
-        "ssb-conn-staging": "~0.1.0",
-        "ssb-ref": "^2.14.2",
-        "ssb-typescript": "^2.1.0",
+        "ssb-conn-db": "~1.0.1",
+        "ssb-conn-hub": "~1.0.0",
+        "ssb-conn-query": "~1.0.0",
+        "ssb-conn-staging": "~1.0.0",
+        "ssb-ref": "^2.14.3",
+        "ssb-typescript": "^2.2.0",
         "statistics": "^3.3.0",
-        "zii": "~1.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        }
+        "ziii": "~1.0.2"
       }
     },
     "ssb-conn-db": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/ssb-conn-db/-/ssb-conn-db-0.3.3.tgz",
-      "integrity": "sha512-N2C/PweOlzEnrcfhGusnFhrZusfGyEMqip2WpQR/dgLAwHHQK8Wxn9KkC0457AHYlIO3UDH4Q1Mewsz8RLweMw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ssb-conn-db/-/ssb-conn-db-1.0.1.tgz",
+      "integrity": "sha512-lTXhHmJ9La7S+YFotLnvn+4uxX5lP+zDNS3N4zPnDDy/3f1AQI6jxEnRDmbhfWqrAEI2gy7Yu6LcgC5rX+MRDA==",
       "requires": {
         "atomic-file": "^2.1.1",
-        "debug": "~4.1.1",
+        "debug": "^4.3.1",
         "multiserver-address": "~1.0.1",
         "pull-notify": "~0.1.1",
         "ssb-ref": "~2.13.9"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
         "ssb-ref": {
           "version": "2.13.9",
           "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.13.9.tgz",
@@ -8594,9 +8560,9 @@
       }
     },
     "ssb-conn-hub": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/ssb-conn-hub/-/ssb-conn-hub-0.2.7.tgz",
-      "integrity": "sha512-fvX7HK44V65C8uMQhTK9B4SHZE7K5P0AU/cHVuDciKPNagEFV0QHKk//JnrrMKHKKvz1msKUxhA0S0iH0S4gqQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ssb-conn-hub/-/ssb-conn-hub-1.0.0.tgz",
+      "integrity": "sha512-YVtQqWmmfT/rDmlCzalP52DsYPF0nUGyADa2Tmvd3gXPS65WnwOA8rtkiDEcTs52OPM+yTO8uG7qLkW534KkKA==",
       "requires": {
         "debug": "^4.1.1",
         "ip": "^1.1.5",
@@ -8623,19 +8589,19 @@
       }
     },
     "ssb-conn-query": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/ssb-conn-query/-/ssb-conn-query-0.4.6.tgz",
-      "integrity": "sha512-qwa0xYK4r3DwbJQQ/K5umw4VAt3aGTkRbFN0E43Mb33+M94jnXMhDIxZWrPoX1vVQSRZLlCb+laXQiGlxW32AQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ssb-conn-query/-/ssb-conn-query-1.0.0.tgz",
+      "integrity": "sha512-sAxy+nJ6B5S9mYuEGT/aMFkPzDKuABdM1eC9XEAvIK8MS3nssjlKe216Tgo63ds4hyK/dghr5D4gd+o5WMcaQA==",
       "requires": {
-        "ssb-conn-db": "~0.3.3",
-        "ssb-conn-hub": "~0.2.7",
-        "ssb-conn-staging": "~0.1.0"
+        "ssb-conn-db": "~1.0.0",
+        "ssb-conn-hub": "~1.0.0",
+        "ssb-conn-staging": "~1.0.0"
       }
     },
     "ssb-conn-staging": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/ssb-conn-staging/-/ssb-conn-staging-0.1.0.tgz",
-      "integrity": "sha512-bFtArSUiF3QrJ9LJ1auonC40pxJd58eBzozBiWsburwbZLUuxqrnW/kCaoyu+PYwTvc0FvMzZR/g4yL2wcE4Yw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ssb-conn-staging/-/ssb-conn-staging-1.0.0.tgz",
+      "integrity": "sha512-NOy1qZoBkhH0XNzLteaaKKePXigEJSCntD4RPRU6vWLMlQ10+SzlIz4TWKgvEVx0LfCe6tEx/vhQf6vBWO/Ylw==",
       "requires": {
         "debug": "^4.1.1",
         "multiserver-address": "~1.0.1",
@@ -9470,10 +9436,10 @@
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
-    "zii": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/zii/-/zii-1.1.0.tgz",
-      "integrity": "sha512-l4EKO8dgLsEWxdb/koCjv92FplAIAQaV4Riq5n/38dTC7Z3NwaFSKQ5Bda+CUTu11VtFE1D+4+HPfPt7/86CRw=="
+    "ziii": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ziii/-/ziii-1.0.2.tgz",
+      "integrity": "sha512-q1FogtBIchy1W0fkxUpe6A4n4WUvAM+hAHN1J6LjBNCV42ZegeC5JSz0mcNv4qxnI0V4cL4FNeEhPMm97Ed0kA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "secret-stack": "^6.3.2",
     "ssb-blob-files": "https://github.com/ssbc/ssb-blob-files#browser-support",
     "ssb-caps": "^1.1.0",
-    "ssb-conn": "^1.0.0",
+    "ssb-conn": "^2.0.2",
     "ssb-db2": "^1.17.0",
     "ssb-friends": "^4.4.4",
     "ssb-keys": "^8.0.2",


### PR DESCRIPTION
This updates ssb-conn to the newly-released 2.0.2 version which no longer uses zii, which means Object.prototype isn't polluted with a .z() function.  Meaning we can use IPFS and other libraries which might optionally have a .z attribute to objects.

(Haven't tested this.  But the changes seem sane.)