### PR TITLE
Fix path issue which kept directory-based npm installs from working

### DIFF
--- a/ssb-singleton.js
+++ b/ssb-singleton.js
@@ -18,7 +18,7 @@ module.exports.init = function (config, extraModules, ssbLoaded) {
     if (window.updateFirstTimeLoading)
       window.updateFirstTimeLoading()
 
-    require('ssb-browser-core/core').init("/.ssb-lite", config, extraModules)
+    require('./core').init("/.ssb-lite", config, extraModules)
     SSB.uniqueID = (new Date()).getTime()
     window.singletonSSB = SSB // Using a different name so that anything trying to use the non-singleton global will fail so we can find them.
 


### PR DESCRIPTION
Fix a path issue in ssb-singleton where if you did an `npm install` on a checked out ssb-browser-core branch, npm couldn't walk the dependency tree correctly.