### PR TITLE
Don't try to ping if running on a DHT connection

### DIFF
--- a/net.js
+++ b/net.js
@@ -117,7 +117,8 @@ exports.init = function(dir, overwriteConfig, extraModules) {
       })
     }
 
-    ping()
+    if (peer.data.type != 'dht')
+      ping()
   })
 
   r.on('replicate:finish', function () {


### PR DESCRIPTION
If running on a DHT connection, don't try to do a tunnel ping, since that doesn't work and just causes errors.